### PR TITLE
Feature/default namespace and provider

### DIFF
--- a/terraflow/libraries/docs.py
+++ b/terraflow/libraries/docs.py
@@ -46,10 +46,6 @@ class TerraformDocumentation:
         # Check is the user wants to use cache documentation
         if self.use_cache:
             # Set the documentation directory
-            print(DOCUMENTATION_DIR)
-            print(self.namespace)
-            print(self.provider)
-            print(self.version)
             documentation_dir = os.path.join(DOCUMENTATION_DIR, self.namespace, self.provider, self.version)
 
             # Set the filepath

--- a/terraflow/libraries/helpers.py
+++ b/terraflow/libraries/helpers.py
@@ -951,7 +951,7 @@ def get_namespaces_and_providers():
         return None, None
 
     # Parse the command output
-    pattern = fr"provider\[registry\.terraform\.io/(.*?)/(.*?)\] (\S+)"
+    pattern = fr"provider\[registry\.terraform\.io/(.*?)/(.*?)\]\s?(\S+)?"
     match = re.findall(pattern, result.stdout, re.MULTILINE)
     if match:
         # Separate namespaces and providers and convert to sets to get unique values

--- a/terraflow/libraries/options.py
+++ b/terraflow/libraries/options.py
@@ -9,14 +9,9 @@ from .helpers import get_namespaces_and_providers
 
 import os
 
-# def get_config_file_path():
-#     if os.getcwd().endswith('terraform'):
-#         return '.terraflow.yaml'
-#     else:
-#         return 'terraform/.terraflow.yaml'
+#TODO: Add support for using configuration files for defaults
 
 def namespace_option_default():
-    # config = read_yaml_file(filename=get_config_file_path())
     namespaces, providers = get_namespaces_and_providers()
 
     if namespaces:
@@ -26,7 +21,6 @@ def namespace_option_default():
     return None
 
 def provider_option_default():
-    # config = read_yaml_file(filename=get_config_file_path())
     namespaces, providers = get_namespaces_and_providers()
 
     if providers:
@@ -54,10 +48,8 @@ options = {
         "--namespace",
         type=str,
         default=namespace_default if namespace_default else 'hashicorp',
-        # default='hashicorp',
         multiple=False,
         required=False if namespace_default else True,
-        # required=True,
         help="The namespace of the Terraform provider.",
     ),
     "provider": click.option(
@@ -66,7 +58,6 @@ options = {
         default=provider_default,
         multiple=False,
         required=False if provider_default else True,
-        # required=True,
         help="The name of the Terraform provider.",
     ),
     "kind": click.option(

--- a/terraflow/libraries/options.py
+++ b/terraflow/libraries/options.py
@@ -5,7 +5,7 @@ from enum import Enum
 import os
 import click
 
-from .helpers import read_yaml_file, get_terraform_providers, get_namespaces_and_providers
+from .helpers import get_namespaces_and_providers
 
 import os
 
@@ -15,33 +15,29 @@ import os
 #     else:
 #         return 'terraform/.terraflow.yaml'
 
-# def namespace_option_default():
-#     config = read_yaml_file(filename=get_config_file_path())
-#     namespaces, providers = get_namespaces_and_providers()
+def namespace_option_default():
+    # config = read_yaml_file(filename=get_config_file_path())
+    namespaces, providers = get_namespaces_and_providers()
 
-#     if namespaces:
-#         if config and 'namespace' in config and config['namespace'] in namespaces:
-#             return config['namespace']
-#         elif len(namespaces) == 1:
-#             return namespaces[0]
-#     else:
-#         return None
+    if namespaces:
+        if len(namespaces) == 1:
+            return namespaces[0]
+    
+    return None
 
-# def provider_option_default():
-#     config = read_yaml_file(filename=get_config_file_path())
-#     namespaces, providers = get_namespaces_and_providers()
+def provider_option_default():
+    # config = read_yaml_file(filename=get_config_file_path())
+    namespaces, providers = get_namespaces_and_providers()
 
-#     if providers:
-#         if config and 'provider' in config and config['provider'] in providers:
-#             return config['provider']
-#         elif len(providers) == 1:
-#             return providers[0]
-#     else:
-#         return None
+    if providers:
+        if len(providers) == 1:
+            return providers[0]
+    else:
+        return None
 
 
-# namespace_default = namespace_option_default()
-# provider_default = provider_option_default()
+namespace_default = namespace_option_default()
+provider_default = provider_option_default()
 
 # Dictionary of different CLI options
 options = {
@@ -57,20 +53,20 @@ options = {
     "namespace": click.option(
         "--namespace",
         type=str,
-        # default=namespace_default if namespace_default else 'hashicorp',
-        default='hashicorp',
+        default=namespace_default if namespace_default else 'hashicorp',
+        # default='hashicorp',
         multiple=False,
-        # required=False if namespace_default else True,
-        required=True,
+        required=False if namespace_default else True,
+        # required=True,
         help="The namespace of the Terraform provider.",
     ),
     "provider": click.option(
         "--provider",
         type=str,
-        # default=provider_default,
+        default=provider_default,
         multiple=False,
-        # required=False if provider_default else True,
-        required=True,
+        required=False if provider_default else True,
+        # required=True,
         help="The name of the Terraform provider.",
     ),
     "kind": click.option(


### PR DESCRIPTION
This pull request add features to support a default `namespace` and default `provider` if there is only one in the configuration.  For example, in a configuration where you have only `azurerm` as the provider you will not need to pass the `--provider` flag and specify `azurerm`.  However, if you have `azurerm` and `aws` providers in a configuration, for example, you would have to pass the provider using the `--provider` flag.